### PR TITLE
Remove default rpcpassword

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -87,8 +87,7 @@ Bitcoin.DEFAULT_CONFIG_SETTINGS = {
   zmqpubrawtx: 'tcp://127.0.0.1:28332',
   zmqpubhashblock: 'tcp://127.0.0.1:28332',
   rpcallowip: '127.0.0.1',
-  rpcuser: 'bitcoin',
-  rpcpassword: 'local321',
+  rpcuser: 'bitcoin', /* NOTE: rpcpassword=[[random]] must be set in btcprivate.conf */
   uacomment: 'bitcore',
   showmetrics: 0
 };


### PR DESCRIPTION
```
  _.extend(this.spawn.config, this._getDefaultConf());
  _.extend(this.spawn.config, this._parseBitcoinConf(configPath));
```

`configPath`, e.g. `~/.btcprivate/btcprivate.conf`, now must contain the randomized password created by bitcore-install